### PR TITLE
Fixing Azure GW default size

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The following variables are optional:
 
 key | default | value
 :---|:---|:---
-instance_size | Standard_B1s | Size of the transit gateway instances
+instance_size | Standard_B1ms | Size of the transit gateway instances
 ha_gw | true | Set to false to deploy a single transit GW
 
 ### Outputs

--- a/variables.tf
+++ b/variables.tf
@@ -16,7 +16,7 @@ variable "azure_account_name" {
 variable "instance_size" {
     description = "Azure Instance size for the Aviatrix gateways"
     type = string
-    default = "Standard_B1s"
+    default = "Standard_B1ms"
 }
 
 variable "ha_gw" {


### PR DESCRIPTION
Gateway size Standard_B1s not supported. Supported sizes are: ['Standard_B1ms', 'Standard_B2ms', ... @Dennizz 